### PR TITLE
Add support for multiple webprocesses per view

### DIFF
--- a/src/ipc-android.h
+++ b/src/ipc-android.h
@@ -3,8 +3,7 @@
 namespace IPC {
 
 struct PoolConstruction {
-    uint32_t poolID;
-    uint8_t padding[20];
+    uint8_t padding[24];
 
     static const uint64_t code = 4;
     static void construct(Message& message, const PoolConstruction& data)
@@ -22,12 +21,92 @@ struct PoolConstruction {
 };
 static_assert(sizeof(PoolConstruction) == Message::dataSize, "PoolConstruction is of correct size");
 
+struct PoolConstructionReply {
+    uint32_t poolID;
+    uint8_t padding[20];
+
+    static const uint64_t code = 5;
+    static void construct(Message& message, const PoolConstructionReply& data)
+    {
+        message.messageCode = code;
+        std::memcpy(&message.messageData, &data, Message::dataSize);
+    }
+
+    static PoolConstructionReply from(const Message& message)
+    {
+        PoolConstructionReply data;
+        std::memcpy(&data, &message.messageData, Message::dataSize);
+        return data;
+    }
+};
+static_assert(sizeof(PoolConstructionReply) == Message::dataSize, "PoolConstructionReply is of correct size");
+
+struct PoolPurge {
+    uint32_t poolID;
+    uint8_t padding[20];
+
+    static const uint64_t code = 6;
+    static void construct(Message& message, const PoolPurge& data)
+    {
+        message.messageCode = code;
+        std::memcpy(&message.messageData, &data, Message::dataSize);
+    }
+
+    static PoolPurge from(const Message& message)
+    {
+        PoolPurge data;
+        std::memcpy(&data, &message.messageData, Message::dataSize);
+        return data;
+    }
+};
+static_assert(sizeof(PoolPurge) == Message::dataSize, "PoolPurge is of correct size");
+
+struct RegisterPool {
+    uint32_t poolID;
+    uint8_t padding[20];
+
+    static const uint64_t code = 7;
+    static void construct(Message& message, const RegisterPool& data)
+    {
+        message.messageCode = code;
+        std::memcpy(&message.messageData, &data, Message::dataSize);
+    }
+
+    static RegisterPool from(const Message& message)
+    {
+        RegisterPool data;
+        std::memcpy(&data, &message.messageData, Message::dataSize);
+        return data;
+    }
+};
+static_assert(sizeof(RegisterPool) == Message::dataSize, "RegisterPool is of correct size");
+
+struct UnregisterPool {
+    uint32_t poolID;
+    uint8_t padding[20];
+
+    static const uint64_t code = 8;
+    static void construct(Message& message, const UnregisterPool& data)
+    {
+        message.messageCode = code;
+        std::memcpy(&message.messageData, &data, Message::dataSize);
+    }
+
+    static UnregisterPool from(const Message& message)
+    {
+        UnregisterPool data;
+        std::memcpy(&data, &message.messageData, Message::dataSize);
+        return data;
+    }
+};
+static_assert(sizeof(UnregisterPool) == Message::dataSize, "UnregisterPool is of correct size");
+
 struct BufferAllocation {
     uint32_t poolID;
     uint32_t bufferID;
     uint8_t padding[16];
 
-    static const uint64_t code = 8;
+    static const uint64_t code = 10;
     static void construct(Message& message, const BufferAllocation& data)
     {
         message.messageCode = code;
@@ -86,12 +165,21 @@ struct ReleaseBuffer {
 static_assert(sizeof(ReleaseBuffer) == Message::dataSize, "ReleaseBuffer is of correct size");
 
 struct FrameComplete {
-    uint8_t padding[24];
+    uint32_t poolID;
+    uint8_t padding[20];
 
     static const uint64_t code = 23;
-    static void construct(Message& message)
+    static void construct(Message& message, const FrameComplete& data)
     {
         message.messageCode = code;
+        std::memcpy(&message.messageData, &data, Message::dataSize);
+    }
+
+    static FrameComplete from(const Message& message)
+    {
+        FrameComplete data;
+        std::memcpy(&data, &message.messageData, Message::dataSize);
+        return data;
     }
 };
 static_assert(sizeof(FrameComplete) == Message::dataSize, "FrameComplete is of correct size");

--- a/src/ipc.h
+++ b/src/ipc.h
@@ -27,6 +27,7 @@
 #ifndef wpe_mesa_ipc_h
 #define wpe_mesa_ipc_h
 
+#include <functional>
 #include <gio/gio.h>
 #include <memory>
 #include <stdint.h>
@@ -58,7 +59,7 @@ public:
     void deinitialize();
 
     int socketFd();
-    int releaseClientFD();
+    int releaseClientFD(bool closeSourceFd = false);
 
     void sendMessage(char*, size_t);
 
@@ -87,6 +88,7 @@ public:
     int socketFd();
 
     void sendMessage(char*, size_t);
+    void sendReceiveMessage(char*, size_t, std::function<void(char*, size_t)> handler);
 
 private:
     static gboolean socketCallback(GSocket*, GIOCondition, gpointer);

--- a/src/renderer-host.cpp
+++ b/src/renderer-host.cpp
@@ -1,10 +1,265 @@
+#include "renderer-host.h"
+
 #include "interfaces.h"
+
+#include <cstdint>
+#include <memory>
+#include <unistd.h>
+
+#include "ipc.h"
+#include "ipc-android.h"
+#include "logging.h"
+
+
+uint32_t m_lastExportedPoolID = 0;
+
+class RendererHostClientProxy final : public IPC::Host::Handler {
+public:
+    RendererHostClientProxy(RendererHost& host);
+    ~RendererHostClientProxy();
+
+    int releaseClientFD();
+
+    IPC::Host& ipc() { return m_ipcHost; }
+
+private:
+
+    void constructPool();
+    void purgePool(uint32_t poolId);
+    void bufferAllocation(AHardwareBuffer* buffer, uint32_t, uint32_t);
+    void bufferCommit(uint32_t, uint32_t);
+
+    // IPC::Host::Handle
+    void handleMessage(char*, size_t) override;
+
+    RendererHost& m_host;
+
+    IPC::Host m_ipcHost;
+};
+
+// BufferPool
+
+BufferPool::BufferPool(uint32_t id, RendererHostClientProxy* client)
+    : m_id(id), m_client(client) {
+    m_buffers = { nullptr, nullptr, nullptr, nullptr };
+}
+
+// RendereHost
+
+RendererHost::RendererHost() = default;
+
+RendererHost& RendererHost::instance() {
+    static RendererHost host;
+    return host;
+}
+
+// There's one client created per webprocess
+int RendererHost::createClient() {
+    ALOGV("RendererHost::createClient()");
+
+    auto* clientProxy = new RendererHostClientProxy(*this);
+    m_clients.push_back(clientProxy);
+    return clientProxy->releaseClientFD();
+}
+
+uint32_t RendererHost::createBufferPool(RendererHostClientProxy* client) {
+    ALOGV("RendererHost::createBufferPool()");
+    static uint32_t poolID = 0;
+
+    auto* bufferPool = new BufferPool(poolID++, client);
+    m_bufferPoolMap.insert({ bufferPool->id(), bufferPool });
+    return bufferPool->id();
+}
+
+BufferPool* RendererHost::findBufferPool(uint32_t poolID) {
+    auto it = m_bufferPoolMap.find(poolID);
+    if (it == m_bufferPoolMap.end())
+        g_error("RendererHost::findBufferPool(): " "Cannot find buffer pool with poolId %" PRIu32 " in render host.", poolID);
+    return it->second;
+}
+
+void RendererHost::registerViewBackend(uint32_t poolId, Exportable::ViewBackend* viewBackend) {
+    m_viewBackendMap.insert({ poolId, viewBackend });
+}
+
+void RendererHost::unregisterViewBackend(uint32_t poolId) {
+    auto it = m_viewBackendMap.find(poolId);
+    if (it != m_viewBackendMap.end()) {
+        m_viewBackendMap.erase(it);
+    }
+}
+
+Exportable::ViewBackend* RendererHost::findViewBackend(uint32_t poolId) {
+    auto it = m_viewBackendMap.find(poolId);
+    if (it == m_viewBackendMap.end())
+        g_error("RendererHost::findViewBackend(): " "Cannot find view backend with poolId %" PRIu32 " in render host.", poolId);
+    return it->second;
+}
+
+void RendererHost::releaseBuffer(AHardwareBuffer* buffer, uint32_t poolID, uint32_t bufferID) {
+    auto* bufferPool = findBufferPool(poolID);
+
+    IPC::ReleaseBuffer release;
+    release.poolID = poolID;
+    release.bufferID = bufferID;
+
+    IPC::Message message;
+    IPC::ReleaseBuffer::construct(message, release);
+    bufferPool->client()->ipc().sendMessage(IPC::Message::data(message), IPC::Message::size);
+}
+
+void RendererHost::frameComplete() {
+    auto* bufferPool = findBufferPool(m_lastExportedPoolID);
+
+    IPC::FrameComplete frameComplete;
+    frameComplete.poolID = m_lastExportedPoolID;
+
+    IPC::Message message;
+    IPC::FrameComplete::construct(message, frameComplete);
+    bufferPool->client()->ipc().sendMessage(IPC::Message::data(message), IPC::Message::size);
+}
+
+// RendereHostClientProxy
+
+RendererHostClientProxy::RendererHostClientProxy(RendererHost& host)
+    : m_host(host) {
+    m_ipcHost.initialize(*this);
+}
+
+RendererHostClientProxy::~RendererHostClientProxy() {
+    m_ipcHost.deinitialize();
+}
+
+int RendererHostClientProxy::releaseClientFD() {
+    return m_ipcHost.releaseClientFD(true);
+}
+
+void RendererHostClientProxy::constructPool()
+{
+    uint32_t poolID = m_host.createBufferPool(this);
+
+    IPC::PoolConstructionReply poolConstructionReply;
+    poolConstructionReply.poolID = poolID;
+
+    IPC::Message message;
+    IPC::PoolConstructionReply::construct(message, poolConstructionReply);
+    m_ipcHost.sendMessage(IPC::Message::data(message), IPC::Message::size);
+}
+
+void RendererHostClientProxy::purgePool(uint32_t poolId) {
+    auto* bufferPool = m_host.findBufferPool(poolId);
+
+    for(int i=0; i<bufferPool->size(); i++) {
+        auto* buffer = bufferPool->getBuffer(i);
+        if (buffer)
+            AHardwareBuffer_release(buffer);
+        bufferPool->setBuffer(i, nullptr);
+    }
+}
+
+void RendererHostClientProxy::bufferAllocation(AHardwareBuffer* buffer, uint32_t poolID, uint32_t bufferID)
+{
+    auto* bufferPool = m_host.findBufferPool(poolID);
+
+    if (bufferID >= bufferPool->size()) {
+        if (buffer)
+            AHardwareBuffer_release(buffer);
+        return;
+    }
+
+    if (bufferPool->getBuffer(bufferID))
+        AHardwareBuffer_release(bufferPool->getBuffer(bufferID));
+    bufferPool->setBuffer(bufferID, buffer);
+}
+
+void RendererHostClientProxy::bufferCommit(uint32_t poolID, uint32_t bufferID)
+{
+    auto* bufferPool = m_host.findBufferPool(poolID);
+
+    if (bufferID >= bufferPool->size())
+        return;
+
+    auto* buffer = bufferPool->getBuffer(bufferID);
+    ALOGV(" RendererHostClientProxy::bufferCommit: committing pool buffer %p\n", buffer);
+
+    // TODO: This is only temprorary solution for PSON support. To make this work correctly
+    // interface change is needed where we received pool id from frame complete callback.
+    m_lastExportedPoolID = poolID;
+
+    auto* viewBackend = m_host.findViewBackend(poolID);
+    auto* clientBundle = viewBackend->clientBundle();
+    if (clientBundle->client && clientBundle->client->export_buffer)
+        clientBundle->client->export_buffer(clientBundle->data, buffer, poolID, bufferID);
+}
+
+void RendererHostClientProxy::handleMessage(char*data, size_t size) {
+    ALOGV("RendererHostClientProxy::handleMessage() %p[%zu]", data, size);
+    if (size != IPC::Message::size)
+        return;
+
+    auto& message = IPC::Message::cast(data);
+    switch (message.messageCode) {
+    case IPC::PoolConstruction::code:
+    {
+        ALOGV("  PoolConstruction");
+        constructPool();
+        break;
+    }
+    case IPC::PoolPurge::code:
+    {
+        auto purge = IPC::PoolPurge::from(message);
+        ALOGV("  PoolPurge: poolID %d", purge.poolID);
+        purgePool(purge.poolID);
+        break;
+    }
+    case IPC::BufferAllocation::code:
+    {
+        auto allocation = IPC::BufferAllocation::from(message);
+
+        ALOGV("  BufferAllocation: poolID %u, bufferID %u", allocation.poolID, allocation.bufferID);
+
+        AHardwareBuffer* buffer = nullptr;
+        int ret = 0;
+        while (true) {
+            ret = AHardwareBuffer_recvHandleFromUnixSocket(m_ipcHost.socketFd(), &buffer);
+            if (!ret || ret != -EAGAIN)
+                break;
+        }
+        ALOGV("  BufferAllocation: ret %d, buffer %p\n", ret, buffer);
+
+        bufferAllocation(buffer, allocation.poolID, allocation.bufferID);
+        break;
+    }
+    case IPC::BufferCommit::code:
+    {
+        auto commit = IPC::BufferCommit::from(message);
+        ALOGV("  BufferCommit: poolID %u, bufferID %u", commit.poolID, commit.bufferID);
+        bufferCommit(commit.poolID, commit.bufferID);
+        break;
+    }
+    default:
+        ALOGV("RendererHostClientProxy: invalid message");
+        break;
+    }
+}
 
 struct wpe_renderer_host_interface android_renderer_host_impl = {
     // create
-    [] () -> void* { return nullptr; },
+    [] () -> void* {
+        ALOGV("wpe_renderer_host_interface - create");
+        // libwpe stores value returned by this call as static singleton without any other usage.
+        // This is called once prior to wpe_renderer_host_create_client calls.
+        // Renderer host can be considered as singleton and thus no need to return anything
+        // as libwpe doesn't use returned value. This is similar approach to wpebackend-fdo.
+        return nullptr;
+    },
     // destroy
-    [] (void*) { },
+    [] (void* data) {
+        // wpewebkit/libwpe never calls this
+    },
     // create_client
-    [] (void*) -> int { return -1; },
+    [] (void* data) -> int {
+        ALOGV("wpe_renderer_host_interface - create_client");
+        return RendererHost::instance().createClient();
+    },
 };

--- a/src/renderer-host.h
+++ b/src/renderer-host.h
@@ -1,0 +1,61 @@
+#pragma once
+
+#include "view-backend.h"
+#include <android/hardware_buffer.h>
+#include <array>
+#include <cstdint>
+#include <sys/types.h>
+#include <unordered_map>
+#include <vector>
+
+class RendererHostClientProxy;
+
+class BufferPool {
+public:
+    BufferPool(uint32_t id, RendererHostClientProxy* client);
+
+    uint32_t id() const { return m_id; }
+
+    RendererHostClientProxy* client() const { return m_client; }
+
+    size_t size() const { return m_buffers.size(); }
+
+    AHardwareBuffer* getBuffer(int bufferId) { return m_buffers[bufferId]; }
+    void setBuffer(int bufferId, AHardwareBuffer* buffer) { m_buffers[bufferId] = buffer; }
+
+private:
+    uint32_t m_id;
+    RendererHostClientProxy* m_client;
+    std::array<AHardwareBuffer*, 4> m_buffers;
+};
+
+class RendererHost final {
+public:
+    RendererHost();
+
+    static RendererHost& instance();
+
+    int createClient();
+
+    uint32_t createBufferPool(RendererHostClientProxy* client);
+
+    BufferPool* findBufferPool(uint32_t);
+
+    void registerViewBackend(uint32_t poolId, Exportable::ViewBackend* viewBackend);
+    void unregisterViewBackend(uint32_t poolId);
+
+    Exportable::ViewBackend* findViewBackend(uint32_t);
+
+    void releaseBuffer(AHardwareBuffer* buffer, uint32_t poolID, uint32_t bufferID);
+    void frameComplete();
+
+private:
+
+    // (poolId -> BufferPool)
+    std::unordered_map<uint32_t, BufferPool*> m_bufferPoolMap;
+
+    // (poolId -> ViewBackend)
+    std::unordered_map<uint32_t, Exportable::ViewBackend*> m_viewBackendMap;
+
+    std::vector<RendererHostClientProxy*> m_clients;
+};

--- a/src/view-backend.h
+++ b/src/view-backend.h
@@ -1,0 +1,45 @@
+#pragma once
+
+#include <android/hardware_buffer.h>
+#include <wpe-android/view-backend-exportable.h>
+
+#include "ipc.h"
+
+namespace Exportable {
+
+class ViewBackend;
+
+struct ClientBundle {
+    const struct wpe_android_view_backend_exportable_client* client;
+    void* data;
+
+    ViewBackend* viewBackend;
+    uint32_t width;
+    uint32_t height;
+};
+
+class ViewBackend : public IPC::Host::Handler {
+public:
+    ViewBackend(ClientBundle*, struct wpe_view_backend*);
+    virtual ~ViewBackend();
+
+    IPC::Host& ipcHost() { return m_ipcHost; }
+
+    ClientBundle* clientBundle() const { return m_clientBundle; }
+
+    void initialize();
+
+    void frameComplete();
+    void releaseBuffer(AHardwareBuffer*, uint32_t, uint32_t);
+
+private:
+    // IPC::Host::Handler
+    void handleMessage(char*, size_t) override;
+
+    ClientBundle* m_clientBundle;
+    struct wpe_view_backend* m_backend;
+
+    IPC::Host m_ipcHost;
+};
+
+} // namespace Exportable


### PR DESCRIPTION
This is needed for PSON (process swap on navigation) feature
where multiple webprocesses can render and process one view from
different origins.

Features implemented in this patch:

1. WPE render host creates and tracks clients connections to each web
   process and routes communication from view to currently active web
   process.
2. Accelerated surface targets in each webprocess get their own
   buffer pool for rendering. Android WPE render host will deal
   with delegating buffer allocation, commits and swaps correctly
   to owning webprocess targets.
3. Buffer and lifecycle managing per webprocess connection

Closes: [Finish PSON (Process Swap On Navigation) support ](https://github.com/Igalia/wpe-android/projects/1)